### PR TITLE
fix: make unque request code on bluetooth manager

### DIFF
--- a/android/src/main/java/cn/jystudio/bluetooth/RNBluetoothManagerModule.java
+++ b/android/src/main/java/cn/jystudio/bluetooth/RNBluetoothManagerModule.java
@@ -46,8 +46,8 @@ public class RNBluetoothManagerModule extends ReactContextBaseJavaModule
 
 
     // Intent request codes
-    private static final int REQUEST_CONNECT_DEVICE = 1;
-    private static final int REQUEST_ENABLE_BT = 2;
+    private static final int REQUEST_CONNECT_DEVICE = 1835;
+    private static final int REQUEST_ENABLE_BT = 2835;
 
     public static final int MESSAGE_STATE_CHANGE = BluetoothService.MESSAGE_STATE_CHANGE;
     public static final int MESSAGE_READ = BluetoothService.MESSAGE_READ;


### PR DESCRIPTION
Currently this library will make webview upload file crash. Because the request code is conflict with react-native-webview file picker request activity. To prevent the crash, let change the bluetooth manager request code to the unique one.

> I put 1835 because the issue was fixed on 18.35 WIB. Thanks @fajarriandaflip 