### PR TITLE
[CAPT] Improvement: Move registerReceiver from main to each dependecies #CU-86cwqw0pb

### DIFF
--- a/android/src/main/java/cn/jystudio/bluetooth/RNBluetoothManagerModule.java
+++ b/android/src/main/java/cn/jystudio/bluetooth/RNBluetoothManagerModule.java
@@ -9,6 +9,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.pm.PackageManager;
+import android.os.Build;
 import android.os.Bundle;
 import androidx.core.app.ActivityCompat;
 import androidx.core.content.ContextCompat;
@@ -85,7 +86,12 @@ public class RNBluetoothManagerModule extends ReactContextBaseJavaModule
         // Register for broadcasts when a device is discovered
         IntentFilter filter = new IntentFilter(BluetoothDevice.ACTION_FOUND);
         filter.addAction(BluetoothAdapter.ACTION_DISCOVERY_FINISHED);
-        this.reactContext.registerReceiver(discoverReceiver, filter);
+        if (Build.VERSION.SDK_INT >= 34 && this.reactContext.getApplicationInfo().targetSdkVersion >= 34) {
+            this.reactContext.registerReceiver(
+                discoverReceiver, filter, Context.RECEIVER_EXPORTED);
+        } else {
+            this.reactContextcontext.registerReceiver(discoverReceiver, filter);
+        }
     }
 
     @Override


### PR DESCRIPTION
Previously we're fix error `registerReceiver` on application level, but somehow it detect as an error on play console. So I decide to move it to each dependency